### PR TITLE
bumps babel-flow-types dependency and flow version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,20 +15,18 @@
     "jsdoc",
     "jsdocs"
   ],
-  "files": [
-    "index.js"
-  ],
+  "files": ["index.js"],
   "scripts": {
     "test": "jest --coverage"
   },
   "devDependencies": {
     "babylon": "^6.18.0",
-    "flow-bin": "^0.57.3",
+    "flow-bin": "^0.63.1",
     "jest": "^21.2.1",
     "jest-in-case": "^1.0.2",
     "strip-indent": "^2.0.0"
   },
   "dependencies": {
-    "babel-flow-types": "^1.2.2"
+    "babel-flow-types": "^1.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,9 +196,9 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-flow-types@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/babel-flow-types/-/babel-flow-types-1.2.2.tgz#71674e4ab3c41137bdc29278b2ecff82029863c6"
+babel-flow-types@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/babel-flow-types/-/babel-flow-types-1.2.3.tgz#e9c94ac1063a8857f8b2a67c2e17eb6cccd519e3"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.0"
@@ -726,9 +726,9 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-flow-bin@^0.57.3:
-  version "0.57.3"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
+flow-bin@^0.63.1:
+  version "0.63.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.63.1.tgz#ab00067c197169a5fb5b4996c8f6927b06694828"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Need to update babel-flow-types dependency so we have [this change](https://github.com/babel-utils/babel-flow-types/commit/55f1ba03866c49b2627d6cafffbd42e23963c67c) which makes the library compatible with v0.63 of Flow