### PR TITLE
Add support for empty lines inside jsdoc comment blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function normalizeComment(comment /*: Comment */) /*: string */ {
   trimmed.forEach((line, index) => {
     let offset = index === 0 && start === 0 ? startPos : 0;
     let match = line.match(SPACE_UNTIL_CONTENT);
-    if (match) {
+    if (match && !EMPTY_LINE.test(line)) {
       indents.push(offset + match[0].length);
     }
   });

--- a/test.js
+++ b/test.js
@@ -95,11 +95,13 @@ cases('normalizeComments()', opts => {
     code: `
       /**
        * comment
+       * 
        * comment
        */
     `,
     output: `
       comment
+
       comment
     `,
   },


### PR DESCRIPTION
Adjusts normalisation logic so that empty lines in the middle of a comment aren't considered when calculating the indent. 

Previously, the regex for `SPACE_UNTIL_CONTENT` would fail to include the '*' on an empty block comment line, as the * would meet the condition for the look-ahead `(?=\S)`. This would give an inaccurate measure of the smallest indent.

For example, in this example:
```
     /**
       * comment
       * 
       * comment
       */
```

The matches on SPACE_UNTIL_CONTENT would be:
`["  * "]`
`["   "]`
`["  * "]`
The shortest indent value would be length 1, and the '*'s on each line wouldn't be stripped out, leading to the output:

```
* comment
* 
* comment
```


My current solution in this PR is to ignore empty lines when calculating the indent. Keen for feedback if there's a good way to adjust the SPACE_UNTIL_CONTENT regex to handle empty lines.


This was caught while debugging an issue in extract-react-types, where empty lines in JSDoc comments was breaking comment formatting.